### PR TITLE
Ensure the systemd service configuration refers the executable binaries from /usr/bin

### DIFF
--- a/resources/azure-connector.service
+++ b/resources/azure-connector.service
@@ -7,7 +7,7 @@ Requires=mosquitto.service
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/azure-connector -configFile /etc/azure-connector/config.json
+ExecStart=/usr/bin/azure-connector -configFile /etc/azure-connector/config.json
 Restart=always
 
 [Install]


### PR DESCRIPTION
[#1] Ensure the systemd service configuration refers the executable binaries from /usr/bin

The systemd service configuration refers to /usr/bin

Signed-off-by: Trifonova Antonia <Antonia.Trifonova@bosch.io>