### PR TITLE
Fix IDScopeProvider called before reaching out to Azure DPS

### DIFF
--- a/cmd/azure-connector/app/launch.go
+++ b/cmd/azure-connector/app/launch.go
@@ -177,16 +177,9 @@ func MainLoop(settings *azurecfg.AzureSettings, log logger.Logger, idScopeProvid
 	statusPub := connector.NewPublisher(localClient, connector.QosAtLeastOnce, log, nil)
 	defer statusPub.Close()
 
-	connSettings, err := azurecfg.CreateAzureConnectionSettings(settings, log)
+	connSettings, err := azurecfg.PrepareAzureConnectionSettings(settings, idScopeProvider, log)
 	if err != nil {
 		return errors.Wrap(err, "cannot create Azure IoT Hub device connection settings")
-	}
-
-	if len(settings.IDScope) == 0 && idScopeProvider != nil {
-		settings.IDScope, err = idScopeProvider(connSettings)
-		if err != nil {
-			return err
-		}
 	}
 
 	done := make(chan bool, 1)

--- a/config/sas_test.go
+++ b/config/sas_test.go
@@ -34,7 +34,7 @@ func TestGenerateSASToken(t *testing.T) {
 	settings := &config.AzureSettings{ConnectionString: connectionString}
 	logger := logger.NewLogger(log.New(io.Discard, "", log.Ldate), logger.INFO)
 
-	connSettings, err := config.CreateAzureConnectionSettings(settings, logger)
+	connSettings, err := config.PrepareAzureConnectionSettings(settings, nil, logger)
 	require.NoError(t, err)
 
 	sasToken := config.GenerateSASToken(connSettings)

--- a/routing/bus/command_test.go
+++ b/routing/bus/command_test.go
@@ -49,7 +49,7 @@ func TestRegisterCommandMessageHandler(t *testing.T) {
 		ConnectionString: "HostName=dummy-hub.azure-devices.net;DeviceId=dummy-device;SharedAccessKey=dGVzdGF6dXJlc2hhcmVkYWNjZXNza2V5",
 	}
 	logger := logger.NewLogger(log.New(io.Discard, "", log.Ldate), logger.INFO)
-	connSettings, _ := config.CreateAzureConnectionSettings(settings, logger)
+	connSettings, _ := config.PrepareAzureConnectionSettings(settings, nil, logger)
 	router, _ := message.NewRouter(message.RouterConfig{}, watermill.NopLogger{})
 
 	commandHandlers := []handlers.MessageHandler{}
@@ -67,7 +67,7 @@ func TestRegisterCommandMessageHandlerInitializationError(t *testing.T) {
 		ConnectionString: "HostName=dummy-hub.azure-devices.net;DeviceId=dummy-device;SharedAccessKey=dGVzdGF6dXJlc2hhcmVkYWNjZXNza2V5",
 	}
 	logger := logger.NewLogger(log.New(io.Discard, "", log.Ldate), logger.INFO)
-	connSettings, _ := config.CreateAzureConnectionSettings(settings, logger)
+	connSettings, _ := config.PrepareAzureConnectionSettings(settings, nil, logger)
 	router, _ := message.NewRouter(message.RouterConfig{}, watermill.NopLogger{})
 
 	commandHandler := test.NewDummyMessageHandler(testCommandHandlerName, []string{commandName}, errors.New(""))

--- a/routing/bus/telemetry_test.go
+++ b/routing/bus/telemetry_test.go
@@ -45,7 +45,7 @@ func TestNoTelemetryMessageHandlers(t *testing.T) {
 		ConnectionString: "HostName=dummy-hub.azure-devices.net;DeviceId=dummy-device;SharedAccessKey=dGVzdGF6dXJlc2hhcmVkYWNjZXNza2V5",
 	}
 	logger := logger.NewLogger(log.New(io.Discard, "", log.Ldate), logger.INFO)
-	connSettings, _ := config.CreateAzureConnectionSettings(settings, logger)
+	connSettings, _ := config.PrepareAzureConnectionSettings(settings, nil, logger)
 	router, _ := message.NewRouter(message.RouterConfig{}, watermill.NopLogger{})
 
 	telemetryHandlers := []handlers.MessageHandler{}
@@ -58,7 +58,7 @@ func TestTelemetryMessageHandlerWithoutTopics(t *testing.T) {
 		ConnectionString: "HostName=dummy-hub.azure-devices.net;DeviceId=dummy-device;SharedAccessKey=dGVzdGF6dXJlc2hhcmVkYWNjZXNza2V5",
 	}
 	logger := logger.NewLogger(log.New(io.Discard, "", log.Ldate), logger.INFO)
-	connSettings, _ := config.CreateAzureConnectionSettings(settings, logger)
+	connSettings, _ := config.PrepareAzureConnectionSettings(settings, nil, logger)
 	router, _ := message.NewRouter(message.RouterConfig{}, watermill.NopLogger{})
 
 	telemetryHandler := test.NewDummyMessageHandler(testTelemetryHandlerName, []string{}, nil)
@@ -72,7 +72,7 @@ func TestSingleTelemetryMessageHandler(t *testing.T) {
 		ConnectionString: "HostName=dummy-hub.azure-devices.net;DeviceId=dummy-device;SharedAccessKey=dGVzdGF6dXJlc2hhcmVkYWNjZXNza2V5",
 	}
 	logger := logger.NewLogger(log.New(io.Discard, "", log.Ldate), logger.INFO)
-	connSettings, _ := config.CreateAzureConnectionSettings(settings, logger)
+	connSettings, _ := config.PrepareAzureConnectionSettings(settings, nil, logger)
 	router, _ := message.NewRouter(message.RouterConfig{}, watermill.NopLogger{})
 
 	telemetryHandler := test.NewDummyMessageHandler(testTelemetryHandlerName, []string{"telemetry/#"}, nil)
@@ -91,7 +91,7 @@ func TestMultipleTelemetryMessageHandlers(t *testing.T) {
 		ConnectionString: "HostName=dummy-hub.azure-devices.net;DeviceId=dummy-device;SharedAccessKey=dGVzdGF6dXJlc2hhcmVkYWNjZXNza2V5",
 	}
 	logger := logger.NewLogger(log.New(io.Discard, "", log.Ldate), logger.INFO)
-	connSettings, _ := config.CreateAzureConnectionSettings(settings, logger)
+	connSettings, _ := config.PrepareAzureConnectionSettings(settings, nil, logger)
 	router, _ := message.NewRouter(message.RouterConfig{}, watermill.NopLogger{})
 
 	handlerNames := []string{"test_handler_1", "test_handler_2", "test_handler_3"}
@@ -117,7 +117,7 @@ func TestTelemetryMessageHandlerInitializationError(t *testing.T) {
 		ConnectionString: "HostName=dummy-hub.azure-devices.net;DeviceId=dummy-device;SharedAccessKey=dGVzdGF6dXJlc2hhcmVkYWNjZXNza2V5",
 	}
 	logger := logger.NewLogger(log.New(io.Discard, "", log.Ldate), logger.INFO)
-	connSettings, _ := config.CreateAzureConnectionSettings(settings, logger)
+	connSettings, _ := config.PrepareAzureConnectionSettings(settings, nil, logger)
 	router, _ := message.NewRouter(message.RouterConfig{}, watermill.NopLogger{})
 
 	telemetryHandler := test.NewDummyMessageHandler(testTelemetryHandlerName, []string{"telemetry/#"}, errors.New("init error"))

--- a/routing/message/handlers/command/passthrough_handler_test.go
+++ b/routing/message/handlers/command/passthrough_handler_test.go
@@ -38,7 +38,7 @@ func TestPassthroughMessageHandler(t *testing.T) {
 		AllowedCloudMessageTypesList: "testVal,testCommand",
 	}
 	logger := logger.NewLogger(log.New(io.Discard, "", log.Ldate), logger.INFO)
-	connSettings, err := config.CreateAzureConnectionSettings(settings, logger)
+	connSettings, err := config.PrepareAzureConnectionSettings(settings, nil, logger)
 	require.NoError(t, err)
 	messageHandler := &commandPassthroughMessageHandler{}
 

--- a/routing/message/handlers/command/things_handler_test.go
+++ b/routing/message/handlers/command/things_handler_test.go
@@ -39,7 +39,7 @@ func TestThingsMessageHandler(t *testing.T) {
 		AllowedCloudMessageTypesList: "testVal,testCommand",
 	}
 	logger := logger.NewLogger(log.New(io.Discard, "", log.Ldate), logger.INFO)
-	connSettings, err := config.CreateAzureConnectionSettings(settings, logger)
+	connSettings, err := config.PrepareAzureConnectionSettings(settings, nil, logger)
 	require.NoError(t, err)
 	messageHandler := &commandThingsMessageHandler{}
 
@@ -297,7 +297,7 @@ func createCommandThingsHandler(t *testing.T) handlers.MessageHandler {
 		AllowedCloudMessageTypesList: "testVal,testCommand",
 	}
 	logger := logger.NewLogger(log.New(io.Discard, "", log.Ldate), logger.INFO)
-	connSettings, err := config.CreateAzureConnectionSettings(settings, logger)
+	connSettings, err := config.PrepareAzureConnectionSettings(settings, nil, logger)
 	require.NoError(t, err)
 	messageHandler := &commandThingsMessageHandler{}
 	messageHandler.Init(settings, connSettings)

--- a/routing/message/handlers/telemetry/passthrough_handler_test.go
+++ b/routing/message/handlers/telemetry/passthrough_handler_test.go
@@ -33,7 +33,7 @@ func TestPassthroughMessageHandler(t *testing.T) {
 		AllowedLocalTopicsList: "localTopic1,localTopic2,localTopic3",
 	}
 	logger := logger.NewLogger(log.New(io.Discard, "", log.Ldate), logger.INFO)
-	connSettings, err := config.CreateAzureConnectionSettings(settings, logger)
+	connSettings, err := config.PrepareAzureConnectionSettings(settings, nil, logger)
 	require.NoError(t, err)
 	messageHandler := &passthroughMessageHandler{}
 
@@ -62,7 +62,7 @@ func createPassthroughMessageHandler(t *testing.T) handlers.MessageHandler {
 		ConnectionString: "HostName=dummy-hub.azure-devices.net;DeviceId=dummy-device;SharedAccessKey=dGVzdGF6dXJlc2hhcmVkYWNjZXNza2V5",
 	}
 	logger := logger.NewLogger(log.New(io.Discard, "", log.Ldate), logger.INFO)
-	connSettings, err := config.CreateAzureConnectionSettings(settings, logger)
+	connSettings, err := config.PrepareAzureConnectionSettings(settings, nil, logger)
 	require.NoError(t, err)
 	messageHandler := &passthroughMessageHandler{}
 	require.NoError(t, messageHandler.Init(settings, connSettings))

--- a/routing/message/handlers/telemetry/things_handler_test.go
+++ b/routing/message/handlers/telemetry/things_handler_test.go
@@ -37,7 +37,7 @@ func TestThingsMessageHandler(t *testing.T) {
 		MessageMapperConfig: "../internal/testdata/handlers-mapper-config.json",
 	}
 	logger := logger.NewLogger(log.New(io.Discard, "", log.Ldate), logger.INFO)
-	connSettings, err := config.CreateAzureConnectionSettings(settings, logger)
+	connSettings, err := config.PrepareAzureConnectionSettings(settings, nil, logger)
 	require.NoError(t, err)
 	messageHandler := &telemetryThingsMessageHandler{}
 
@@ -418,7 +418,7 @@ func createTelemetryMessageHandler(t *testing.T) handlers.MessageHandler {
 		MessageMapperConfig: "../internal/testdata/handlers-mapper-config.json",
 	}
 	logger := logger.NewLogger(log.New(io.Discard, "", log.Ldate), logger.INFO)
-	connSettings, err := config.CreateAzureConnectionSettings(settings, logger)
+	connSettings, err := config.PrepareAzureConnectionSettings(settings, nil, logger)
 	require.NoError(t, err)
 	messageHandler := &telemetryThingsMessageHandler{}
 	messageHandler.Init(settings, connSettings)


### PR DESCRIPTION
[#14] IDScopeProvider called too late

- config/connnection_settings.go: CreateAzureConnectionSettings function renamed to PrepareAzureConnectionSettings and added IDScopeProvider parameter to it.
- config/connnection_settings.go: CreateAzureCertificateConnectionSettings function renamed to PrepareAzureCertificateConnectionSettings for naming consistency
- updated all test methods to use the renamed functions

Signed-off-by: Stoyan Zoubev <Stoyan.Zoubev@bosch.io>