### PR TITLE
Decouple common azure connector settings from handlers' settings

### DIFF
--- a/cmd/azure-connector/config.go
+++ b/cmd/azure-connector/config.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2022 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+package main
+
+import (
+	"flag"
+
+	azurecfg "github.com/eclipse-kanto/azure-connector/config"
+)
+
+// AzureSettingsExt extends the general configurable data of the azure Connector with configuration for the message handlers.
+type AzureSettingsExt struct {
+	*azurecfg.AzureSettings
+	PassthroughCommandTopic    string `json:"passthroughCommandTopic"`
+	PassthroughTelemetryTopics string `json:"passthroughTelemetryTopics"`
+}
+
+func defaultAzureSettingsExt() *AzureSettingsExt {
+	azureSettings := azurecfg.DefaultSettings()
+	return &AzureSettingsExt{
+		PassthroughCommandTopic:    "cloud-to-device",
+		PassthroughTelemetryTopics: "device-to-cloud",
+		AzureSettings:              azureSettings,
+	}
+}
+
+func addMessageHandlerFlags(f *flag.FlagSet, settings *AzureSettingsExt) {
+	def := defaultAzureSettingsExt()
+
+	f.StringVar(&settings.PassthroughTelemetryTopics,
+		"passthroughTelemetryTopics", def.PassthroughTelemetryTopics,
+		"The comma-separated list of passthrough telemetry MQTT topics the azure connector listens to on the local broker",
+	)
+	f.StringVar(&settings.PassthroughCommandTopic,
+		"passthroughCommandTopic", def.PassthroughCommandTopic,
+		"The passthrough command MQTT topic where all messages from the cloud are forwarded to on the local broker",
+	)
+}

--- a/cmd/azure-connector/config.go
+++ b/cmd/azure-connector/config.go
@@ -18,7 +18,7 @@ import (
 	azurecfg "github.com/eclipse-kanto/azure-connector/config"
 )
 
-// AzureSettingsExt extends the general configurable data of the azure Connector with configuration for the message handlers.
+// AzureSettingsExt extends the general configurable data of the azure connector with configuration for the message handlers.
 type AzureSettingsExt struct {
 	*azurecfg.AzureSettings
 	PassthroughCommandTopic    string `json:"passthroughCommandTopic"`

--- a/cmd/azure-connector/config_test.go
+++ b/cmd/azure-connector/config_test.go
@@ -27,7 +27,7 @@ const (
 	testConfig = "../../config/testdata/config.json"
 )
 
-func TestConfig(t *testing.T) {
+func TestConfigFile(t *testing.T) {
 	settings := defaultAzureSettingsExt()
 	assert.NoError(t, config.ReadConfig(testConfig, settings))
 	assert.Equal(t, "from-device-to-cloud", settings.PassthroughTelemetryTopics)

--- a/cmd/azure-connector/config_test.go
+++ b/cmd/azure-connector/config_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2022 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+package main
+
+import (
+	"flag"
+	"testing"
+
+	azurecfg "github.com/eclipse-kanto/azure-connector/config"
+	"github.com/eclipse-kanto/azure-connector/flags"
+	"github.com/eclipse-kanto/suite-connector/config"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testConfig = "../../config/testdata/config.json"
+)
+
+func TestConfig(t *testing.T) {
+	settings := defaultAzureSettingsExt()
+	assert.NoError(t, config.ReadConfig(testConfig, settings))
+	assert.Equal(t, "from-device-to-cloud", settings.PassthroughTelemetryTopics)
+	assert.Equal(t, "from-cloud-to-device", settings.PassthroughCommandTopic)
+}
+
+func TestDefaults(t *testing.T) {
+	settings := defaultAzureSettingsExt()
+	assert.NoError(t, settings.Validate())
+	assert.Equal(t, "device-to-cloud", settings.PassthroughTelemetryTopics)
+	assert.Equal(t, "cloud-to-device", settings.PassthroughCommandTopic)
+	assert.Equal(t, azurecfg.DefaultSettings(), settings.AzureSettings)
+}
+
+func TestFlagsSet(t *testing.T) {
+	f := flag.NewFlagSet("testing", flag.ContinueOnError)
+	cmd := defaultAzureSettingsExt()
+	flags.Add(f, cmd.AzureSettings)
+	flags.AddGlobal(f)
+	addMessageHandlerFlags(f, cmd)
+
+	assert.NotNil(t, f.Lookup("passthroughTelemetryTopics"))
+	assert.NotNil(t, f.Lookup("passthroughCommandTopic"))
+}

--- a/config/settings.go
+++ b/config/settings.go
@@ -27,9 +27,6 @@ type AzureSettings struct {
 	SASTokenValidity string `json:"sasTokenValidity"`
 	IDScope          string `json:"idScope"`
 
-	PassthroughCommandTopic    string `json:"passthroughCommandTopic"`
-	PassthroughTelemetryTopics string `json:"passthroughTelemetryTopics"`
-
 	config.LocalConnectionSettings
 	logger.LogSettings
 	config.TLSSettings
@@ -49,8 +46,6 @@ func DefaultSettings() *AzureSettings {
 	}
 	defAzureSettings.LogFile = "logs/azure-connector.log"
 	defAzureSettings.LogFileMaxAge = 28
-	defAzureSettings.PassthroughTelemetryTopics = "device-to-cloud"
-	defAzureSettings.PassthroughCommandTopic = "cloud-to-device"
 	return defAzureSettings
 }
 

--- a/config/settings_test.go
+++ b/config/settings_test.go
@@ -59,8 +59,6 @@ func TestConfigInvalid(t *testing.T) {
 func TestConfig(t *testing.T) {
 	expSettings := DefaultSettings()
 	expSettings.TenantID = "tenant7172"
-	expSettings.PassthroughTelemetryTopics = "from-device-to-cloud"
-	expSettings.PassthroughCommandTopic = "from-cloud-to-device"
 	expSettings.LocalUsername = "localUsername_config"
 	expSettings.LocalPassword = "localPassword_config"
 	expSettings.CACert = ""
@@ -82,8 +80,6 @@ func TestDefaults(t *testing.T) {
 	assert.Equal(t, "defaultTenant", settings.TenantID)
 	assert.Empty(t, settings.ConnectionString)
 	assert.Equal(t, "1h", settings.SASTokenValidity)
-	assert.Equal(t, "device-to-cloud", settings.PassthroughTelemetryTopics)
-	assert.Equal(t, "cloud-to-device", settings.PassthroughCommandTopic)
 	assert.Empty(t, settings.IDScope)
 
 	defConnectorSettings := config.DefaultSettings()

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -54,14 +54,6 @@ func Add(f *flag.FlagSet, settings *config.AzureSettings) {
 		flagSASTokenValidity, def.SASTokenValidity,
 		"The validity period for the generated SAS token for device authentication. Should be a positive integer number followed by a unit suffix, such as '300m', '1h', etc. Valid time units are 'm' (minutes), 'h' (hours), 'd' (days)",
 	)
-	f.StringVar(&settings.PassthroughTelemetryTopics,
-		"passthroughTelemetryTopics", def.PassthroughTelemetryTopics,
-		"The comma-separated list of passthrough telemetry MQTT topics the azure connector listens to on the local broker",
-	)
-	f.StringVar(&settings.PassthroughCommandTopic,
-		"passthroughCommandTopic", def.PassthroughCommandTopic,
-		"The passthrough command MQTT topic where all messages from the cloud are forwarded to on the local broker",
-	)
 	f.StringVar(&settings.IDScope, flagIDScope, def.IDScope,
 		"ID scope for Azure Device Provisioning service",
 	)

--- a/flags/flags_test.go
+++ b/flags/flags_test.go
@@ -66,8 +66,6 @@ func TestFlagsSet(t *testing.T) {
 		"configFile",
 		"tenantId",
 		"connectionString",
-		"passthroughTelemetryTopics",
-		"passthroughCommandTopic",
 		"sasTokenValidity",
 		"idScope",
 		"localAddress",
@@ -85,7 +83,8 @@ func TestFlagsSet(t *testing.T) {
 	for _, flagName := range flagNames {
 		assertFlagExists(t, flagName, f)
 	}
-	assertFlagNotExists(t, "messageMapperConfig", f)
+	assertFlagNotExists(t, "passthroughTelemetryTopics", f)
+	assertFlagNotExists(t, "passthroughCommandTopic", f)
 }
 
 func assertFlagExists(t *testing.T, flagName string, f *flag.FlagSet) {


### PR DESCRIPTION
[#19] Decouple common Azure connector settings from message handlers' settings

- AzureSettings struct now contains only general azure connector settings
- message handlers' specific settings and flags (e.g.passthrough topics) moved to cmd/azure-connector/config.go file

Signed-off-by: Stoyan Zoubev <Stoyan.Zoubev@bosch.io>